### PR TITLE
Send error to client when requesting editor state with open modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Serenade for IntelliJ platform Changelog
 
+## [0.0.8] - 2021-06-02
+### Fixed
+- Slow-down/crash when using Serenade within modals (e.g. preferences window)
+
 ## [0.0.7] - 2021-04-08
 ### Added
 - Updated dependencies to support IntelliJ branch versions 211+ (2021.1+)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = ai.serenade.intellij
 pluginName = Serenade
-pluginVersion = 0.0.7
+pluginVersion = 0.0.8
 pluginSinceBuild = 203
 pluginUntilBuild = 211.*
 

--- a/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
@@ -7,7 +7,6 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ModalityState
-import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.command.undo.UndoManager
 import com.intellij.openapi.editor.CaretState

--- a/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
@@ -202,9 +202,10 @@ class CommandHandler(private val project: Project) {
         remainingCommands: List<Command>,
         read: () -> CallbackData?
     ) {
-        ApplicationManager.getApplication().invokeLater({
-            runCommandsInQueue(callback, remainingCommands, read())
-        }, ModalityState.any())
+        ApplicationManager.getApplication().invokeLater(
+            { runCommandsInQueue(callback, remainingCommands, read()) },
+            ModalityState.any()
+        )
     }
 
     // run some write action and then run remaining commands

--- a/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
@@ -441,7 +441,9 @@ class CommandHandler(private val project: Project) {
         val manager = FileEditorManagerEx.getInstanceEx(project)
         val fileEditor = manager.selectedEditor
         val undoManager = UndoManager.getInstance(project)
-        undoManager.redo(fileEditor)
+        if (undoManager.isRedoAvailable(fileEditor)) {
+            undoManager.redo(fileEditor)
+        }
         return null
     }
 
@@ -449,7 +451,9 @@ class CommandHandler(private val project: Project) {
         val manager = FileEditorManagerEx.getInstanceEx(project)
         val fileEditor = manager.selectedEditor
         val undoManager = UndoManager.getInstance(project)
-        undoManager.undo(fileEditor)
+        if (undoManager.isUndoAvailable(fileEditor)) {
+            undoManager.undo(fileEditor)
+        }
         return null
     }
 }

--- a/src/main/kotlin/ai/serenade/intellij/services/DataTypes.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/DataTypes.kt
@@ -79,7 +79,10 @@ data class NestedData(
 
     // OPEN_FILE_LIST
     val text: String? = null,
-)
+
+    // error state for editor state under modals
+    var error: Boolean? = false,
+    )
 
 val json = Json {
     encodeDefaults = false; // don't include all the null values

--- a/src/main/kotlin/ai/serenade/intellij/services/DataTypes.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/DataTypes.kt
@@ -82,7 +82,7 @@ data class NestedData(
 
     // error state for editor state under modals
     var error: Boolean? = false,
-    )
+)
 
 val json = Json {
     encodeDefaults = false; // don't include all the null values


### PR DESCRIPTION
Currently, if you open a dialog (e.g. the preferences window) in IntelliJ, all Serenade requests get queued until the modal is closed. This causes any commands issued while a modal is open to time out on the client side, and can also cause a crash/unexpected behavior when the dialog is closed since all of the queued commands come in rapidly.

This change checks to make sure there are no modals open and if there are, sends an error response to the editor state requests, telling the client to treat these modals like system dialogs.