### PR TITLE
Fix "go to start of file"

### DIFF
--- a/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
@@ -302,7 +302,7 @@ class CommandHandler(private val project: Project) {
         }
 
         // set source and cursor
-        if (command.source != null && command.cursor != null) {
+        if (command.source != null) {
             // standardize newline endings
             val source = Regex("\\r\\n").replace(command.source, "\n")
             editor.document.replaceString(
@@ -310,9 +310,13 @@ class CommandHandler(private val project: Project) {
                 editor.document.textLength,
                 source
             )
-            val cursor = editor.offsetToLogicalPosition(command.cursor)
+            var cursor = 0
+            if (command.cursor != null) {
+                cursor = command.cursor
+            }
+            val position = editor.offsetToLogicalPosition(cursor)
             editor.caretModel.caretsAndSelections = listOf(
-                CaretState(cursor, cursor, cursor)
+                CaretState(position, position, position)
             )
             editor.scrollingModel.scrollToCaret(ScrollType.RELATIVE)
         }


### PR DESCRIPTION
The source of this bug has to do with how protobuf handles default values -- if the value matches the default, it doesn't get sent as part of the message. Since the default value of the cursor position is 0, trying to set the cursor to this position would result in a no-op.

This change ensures that we have the proper default behavior for diff commands (and parity with the Atom and VS Code plugins).