### PR TITLE
Fix connection problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # Serenade for IntelliJ platform Changelog
 
+## [0.0.11] - 2021-12-07
+
+### Fixed
+- Issue with plugin not disconnecting and reconnecting from client properly
+
 ## [0.0.10] - 2021-08-02
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,8 @@ repositories {
     jcenter()
 }
 dependencies {
-    implementation(kotlin("stdlib", org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION))
-    implementation(kotlin("stdlib-jdk8"))
+    implementation(kotlin("stdlib", "1.5.0-M2"))
+    implementation(kotlin("stdlib-jdk8", "1.5.0-M2"))
     implementation(kotlin("reflect", "1.5.0-M2"))
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.10.0")
     implementation("io.ktor:ktor-client-websockets:$ktorVersion") {
@@ -97,7 +97,10 @@ tasks {
     }
     listOf("compileKotlin", "compileTestKotlin").forEach {
         getByName<KotlinCompile>(it) {
-            kotlinOptions.jvmTarget = "1.8"
+            kotlinOptions {
+                jvmTarget = "1.8"
+                freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+            }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = ai.serenade.intellij
 pluginName = Serenade
-pluginVersion = 0.0.10
+pluginVersion = 0.0.11
 pluginSinceBuild = 203
 pluginUntilBuild =
 

--- a/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/CommandHandler.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import io.ktor.client.features.websocket.DefaultClientWebSocketSession
 import io.ktor.http.cio.websocket.Frame
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.* // ktlint-disable no-wildcard-imports
@@ -146,6 +147,7 @@ class CommandHandler(private val project: Project) {
     }
 
     private fun sendCallback(callback: String, data: CallbackData?) {
+        @OptIn(DelicateCoroutinesApi::class)
         GlobalScope.launch {
             webSocketSession?.send(
                 Frame.Text(

--- a/src/main/kotlin/ai/serenade/intellij/services/IpcService.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/IpcService.kt
@@ -84,7 +84,6 @@ class IpcService(private val project: Project) {
         }
     }
 
-    @KtorExperimentalAPI
     private suspend fun tryConnect() {
         client.ws(
             host = "localhost",

--- a/src/main/kotlin/ai/serenade/intellij/services/IpcService.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/IpcService.kt
@@ -8,6 +8,8 @@ import io.ktor.client.features.websocket.WebSockets
 import io.ktor.client.features.websocket.ws
 import io.ktor.http.cio.websocket.Frame
 import io.ktor.http.cio.websocket.readText
+import io.ktor.util.KtorExperimentalAPI
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -21,7 +23,7 @@ import java.util.UUID
 
 const val RECONNECT_TIMEOUT_MS: Long = 3000
 
-@io.ktor.util.KtorExperimentalAPI
+@KtorExperimentalAPI
 class IpcService(private val project: Project) {
     private var notifier: Notifier = Notifier(project)
     private var connectScope: Job? = null
@@ -42,6 +44,7 @@ class IpcService(private val project: Project) {
     fun start() {
         // ensure that reconnection loop is only started once
         if (connectScope == null) {
+            @OptIn(DelicateCoroutinesApi::class)
             connectScope = GlobalScope.launch {
                 while (true) {
                     // No-op if connected already
@@ -53,16 +56,14 @@ class IpcService(private val project: Project) {
             }
 
             // listen to focus, and update plugin active state
-            WindowManagerEx.getInstance().getFrame(project)
-                ?.addWindowListener(
-                    object : WindowAdapter() {
-                        override fun windowActivated(e: WindowEvent?) {
-                            GlobalScope.launch {
-                                sendAppStatus("active")
-                            }
-                        }
+            WindowManagerEx.getInstance().getFrame(project)?.addWindowListener(
+                object : WindowAdapter() {
+                    override fun windowActivated(e: WindowEvent?) {
+                        @OptIn(DelicateCoroutinesApi::class)
+                        GlobalScope.launch { sendAppStatus("active") }
                     }
-                )
+                }
+            )
         }
     }
 
@@ -76,15 +77,14 @@ class IpcService(private val project: Project) {
                 notifier.notify("Could not connect")
                 shouldNotify = false
             }
-            heartbeatScope?.cancel()
-            toolWindow.setContent(false)
+            onClose()
         } catch (e: Exception) {
             notifier.notify("Could not connect: $e")
-            heartbeatScope?.cancel()
-            toolWindow.setContent(false)
+            onClose()
         }
     }
 
+    @KtorExperimentalAPI
     private suspend fun tryConnect() {
         client.ws(
             host = "localhost",
@@ -95,6 +95,7 @@ class IpcService(private val project: Project) {
 
             // send a heartbeat in a separate coroutine
             id = UUID.randomUUID().toString()
+            @OptIn(DelicateCoroutinesApi::class)
             heartbeatScope = GlobalScope.launch {
                 while (isActive) {
                     sendAppStatus("heartbeat")
@@ -112,16 +113,8 @@ class IpcService(private val project: Project) {
                 }
             }
         }
-
-        // wait for the session to be closed by the client:
-        GlobalScope.launch {
-            webSocketSession?.closeReason?.await()
-            notifier.notify("Disconnected")
-            shouldNotify = true
-            heartbeatScope?.cancel()
-            toolWindow.setContent(false)
-            webSocketSession = null
-        }
+        notifier.notify("Disconnected")
+        webSocketSession = null
     }
 
     private suspend fun sendAppStatus(name: String) {
@@ -151,5 +144,10 @@ class IpcService(private val project: Project) {
             notifier.notify("Failed to parse or execute: " + frame.readText())
             notifier.notify(e.toString())
         }
+    }
+
+    private fun onClose() {
+        heartbeatScope?.cancel()
+        toolWindow.setContent(false)
     }
 }

--- a/src/main/kotlin/ai/serenade/intellij/services/Notifier.kt
+++ b/src/main/kotlin/ai/serenade/intellij/services/Notifier.kt
@@ -3,6 +3,7 @@ package ai.serenade.intellij.services
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -16,6 +17,7 @@ class Notifier(private val project: Project) {
                 "Serenade: $message",
                 NotificationType.INFORMATION
             )
+        @OptIn(DelicateCoroutinesApi::class)
         GlobalScope.launch {
             delay(5000)
             notification.expire()


### PR DESCRIPTION
Previously, the websocket client was only disconnected and reset when it received an explicit close reason from the websocket server run in the Serenade client. In some scenarios (e.g. starting the Serenade client after the plugin was started and then closing the Serenade client), the websocket client never received an explicit close instruction and the session would be left running, preventing further instances of the Serenade client from reconnecting. This change explicitly resets the websocket session whenever the connection is lost.

Other minor changes:
- added annotations to coroutines launched in the global scope, since I'm fairly certain all of our uses are legitimate (see https://blog.jetbrains.com/kotlin/2021/05/kotlin-coroutines-1-5-0-released/#globalscope)
- added experimental API annotations to calls to `setContents`
- factor out an `onClose` method to properly cancel `heartbeatScope` and update tool window contents